### PR TITLE
A couple of fixes for JAWStats

### DIFF
--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -271,9 +271,10 @@ class clsAWStats
         $iEndPos   = strpos($this->sAWStats, ("\nEND_" . $sSection), $iStartPos);
         $max       = 0;
         $aDesc     = $GLOBALS["aDesc"];
-        if (isset($_GET["max"]))
-            $max       = $_GET["max"];
+        if (isset($_REQUEST["max"]))
+            $max       = $_REQUEST["max"];
         $arrStat   = explode("\n", substr($this->sAWStats, ($iStartPos + 1), ($iEndPos - $iStartPos - 1)));
+
         if ($max == 0)
             for ($iIndex = 1; $iIndex < count($arrStat); $iIndex++) {
                 $data_line = explode(' ', $arrStat[$iIndex]);
@@ -362,8 +363,8 @@ function GetConfig()
     }
 
     // check this site config exists
-    if ((isset($_GET["config"]) == true) && (isset($GLOBALS["aConfig"][$_GET["config"]]) == true) && ($GLOBALS['bForceHttpHost'] === false)) {
-        $sConfig = $_GET["config"];
+    if ((isset($_REQUEST["config"]) == true) && (isset($GLOBALS["aConfig"][$_REQUEST["config"]]) == true) && ($GLOBALS['bForceHttpHost'] === false)) {
+        $sConfig = $_REQUEST["config"];
     } else if (($GLOBALS['bUseHttpHost'] === true) && isset($GLOBALS["aConfig"][$_ENV['HTTP_HOST']])) {
         $sConfig = $_ENV['HTTP_HOST'];
     } else if ($GLOBALS['bForceHttpHost'] === false) {
@@ -523,8 +524,8 @@ function SetTranslation()
         return false;
     }
     // check for existence of querystring
-    if ((isset($_GET["lang"]) == true) && (FindTranslation($_GET["lang"]) == true)) {
-        return $_GET["lang"];
+    if ((isset($_REQUEST["lang"]) == true) && (FindTranslation($_REQUEST["lang"]) == true)) {
+        return $_REQUEST["lang"];
     }
     // check for existence of site config
     if ((isset($GLOBALS["g_aConfig"]["language"]) == true) && (FindTranslation($GLOBALS["g_aConfig"]["language"]) == true)) {

--- a/index.php
+++ b/index.php
@@ -75,8 +75,8 @@ if ((isset($g_aConfig["includes"]) == true) && (strlen($g_aConfig["includes"]) >
 }
 
 // get date range and valid log file
-$year           = array_key_exists("year", $_GET) ? $_GET["year"] : NULL;
-$month          = array_key_exists("month", $_GET) ? $_GET["month"] : NULL;
+$year           = array_key_exists("year", $_REQUEST) ? $_REQUEST["year"] : NULL;
+$month          = array_key_exists("month", $_REQUEST) ? $_REQUEST["month"] : NULL;
 $statsname      = array_key_exists("statsname", $g_aConfig) ? $g_aConfig["statsname"] : NULL;
 $parts          = array_key_exists("parts", $g_aConfig) ? $g_aConfig["parts"] : NULL;
 $g_dtStatsMonth = ValidateDate($year, $month);
@@ -104,7 +104,7 @@ if ($clsPage->ValidateView($GLOBALS["sConfigDefaultView"]) != true) {
     Error("BadConfig", "sConfigDefaultView");
 }
 
-$sView = array_key_exists("view", $_GET) ? $_GET["view"] : NULL;
+$sView = array_key_exists("view", $_REQUEST) ? $_REQUEST["view"] : NULL;
 // validate current view
 if ($clsPage->ValidateView($sView) == true) {
     $sCurrentView = $sView;

--- a/xml_history.php
+++ b/xml_history.php
@@ -42,12 +42,12 @@ if ((isset($g_aConfig["includes"]) == true) && (strlen($g_aConfig["includes"]) >
 $g_sConfig = GetConfig();
 $g_aConfig = $aConfig[$g_sConfig];
 
-if (isset($_GET["part"])) {
-    $g_sConfig = $g_sConfig . "." . $_GET["part"];
+if (isset($_REQUEST["part"])) {
+    $g_sConfig = $g_sConfig . "." . $_REQUEST["part"];
 }
 
 // get date range and valid log file
-$g_dtStatsMonth = ValidateDate(isset($_GET["year"]) ? $_GET["year"] : null, isset($_GET["month"]) ? $_GET["month"]
+$g_dtStatsMonth = ValidateDate(isset($_REQUEST["year"]) ? $_REQUEST["year"] : null, isset($_REQUEST["month"]) ? $_REQUEST["month"]
             : null);
 $g_aLogFiles    = GetLogList($g_sConfig, $g_aConfig["statspath"], $g_aConfig["statsname"]);
 

--- a/xml_pages.php
+++ b/xml_pages.php
@@ -42,13 +42,13 @@ if ((isset($g_aConfig["includes"]) == true) && (strlen($g_aConfig["includes"]) >
 $g_sConfig = GetConfig();
 $g_aConfig = $aConfig[$g_sConfig];
 
-if (isset($_GET["part"])) {
-    $g_sConfig = $g_sConfig . "." . $_GET["part"];
+if (isset($_REQUEST["part"])) {
+    $g_sConfig = $g_sConfig . "." . $_REQUEST["part"];
 }
 
 // create class
 $clsAWStats = new clsAWStats($g_sConfig, $g_aConfig["statspath"],
-    /* $g_aConfig["statsname"] */ null, $_GET["year"], $_GET["month"]);
+    /* $g_aConfig["statsname"] */ null, $_REQUEST["year"], $_REQUEST["month"]);
 
 $urlAliasFile = null;
 if (isset($g_aConfig["urlaliasfile"])) {

--- a/xml_stats.php
+++ b/xml_stats.php
@@ -42,17 +42,17 @@ if ((isset($g_aConfig["includes"]) == true) && (strlen($g_aConfig["includes"]) >
 $g_sConfig = GetConfig();
 $g_aConfig = $aConfig[$g_sConfig];
 
-if (isset($_GET["part"])) {
-    $g_sConfig = $g_sConfig . "." . $_GET["part"];
+if (isset($_REQUEST["part"])) {
+    $g_sConfig = $g_sConfig . "." . $_REQUEST["part"];
 }
 
 // create class
 $clsAWStats = new clsAWStats($g_sConfig, $g_aConfig["statspath"], isset($g_aConfig["statsname"]) ? $g_aConfig["statsname"]
-            : null, $_GET["year"], $_GET["month"]);
+            : null, $_REQUEST["year"], $_REQUEST["month"]);
 
 if ($clsAWStats->bLoaded) {
     // create xml
-    $sSection = $_GET["section"];
+    $sSection = $_REQUEST["section"];
     switch ($sSection) {
         case "BROWSER":
         case "DAY":


### PR DESCRIPTION
The first works around the bogus GeoIP data encoding that causes JAWStats to return an empty data set.  The second is a patch I've been carrying for a couple of years now, using $_REQUEST instead of $_GET because there's no reason to distinguish between GET and POSTs..
