### PR TITLE
Fix Sorting Bug on Pages Tab

### DIFF
--- a/js/jawstats_web.js
+++ b/js/jawstats_web.js
@@ -2660,7 +2660,7 @@ function PageLayout_Pages(sPage) {
     $("#content").html(sHTML);
     $("#content").fadeIn(g_iFadeSpeed);
     if (aTable[0] == true) {
-        $(".tablesorter").tablesorter({headers: {2: {sorter: false}, 3: {sorter: 'bandwidth'}, 4: {sorter: false}, 6: {sorter: false}, 8: {sorter: false}}, sortList: [aSort], textExtraction: function(node) {
+        $(".tablesorter").tablesorter({headers: {1: {sorter: 'formatted_number'}, 2: {sorter: false}, 3: {sorter: 'bandwidth'}, 4: {sorter: false}, 6: {sorter: false}, 8: {sorter: false}}, sortList: [aSort], textExtraction: function(node) {
                 return node.innerHTML.replace(',', '');
             }, widgets: ['zebra']});
     }

--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -789,6 +789,17 @@
     });
 
     ts.addParser({
+        id: "formatted_number",
+        is: function(s) {
+            return true;
+        },
+        format: function(s) {
+            return s.replace(',','');
+        },
+        type: "numeric"
+    });
+
+    ts.addParser({
         id: "currency",
         is: function(s) {
             return /^[Â£$â‚¬?.]/.test(s);


### PR DESCRIPTION
The counts in the pages column on the Pages tab formats the counts with commas.  This was breaking sorting because it appeared to be doing a text sort.  This fixes the sort by stripping the commas from the data for sorting.
