### PR TITLE
Fix XML for missing data labels

### DIFF
--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -254,7 +254,9 @@ class clsAWStats
         for ($iIndexItem = 0; $iIndexItem < count($arrData); $iIndexItem++) {
             $sTemp = "";
             for ($iIndexAttr = 0; $iIndexAttr < count($arrData[$iIndexItem]); $iIndexAttr++) {
-                $sTemp .= $this->arrLabel[$sSection][$iIndexAttr] . "=\"" . htmlspecialchars(urldecode(trim($arrData[$iIndexItem][$iIndexAttr]))) . "\" ";
+                if ($this->arrLabel[$sSection][$iIndexAttr]) {
+                    $sTemp .= $this->arrLabel[$sSection][$iIndexAttr] . "=\"" . htmlspecialchars(urldecode(trim($arrData[$iIndexItem][$iIndexAttr]))) . "\" ";
+                }
             }
             $aXML[] = ("<item " . $sTemp . "/>\n");
         }


### PR DESCRIPTION
For some reason unknown to me some labels can be empty when fetching the OS and browser statistics. This results in an invalid XML. This patch makes sure that zero-length labels are not rendered.
