### PR TITLE
Avoid empty files if the encoding isnt ascii

### DIFF
--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -242,7 +242,7 @@ class clsAWStats
         $aXML[] = "</data_exit>\n";
 
         // return
-        return implode($aXML, "");
+        return implode("", $aXML);
     }
 
     function CreateXMLString($sSection)

--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -44,7 +44,7 @@ class clsAWStats
     var $iDailyUniqueAvg = 0;
     var $sFileName       = "";
 
-    function clsAWStats($sStatName, $sFilePath = "", $sFileName = "", $iYear = 0, $iMonth = 0)
+    function __construct($sStatName, $sFilePath = "", $sFileName = "", $iYear = 0, $iMonth = 0)
     {
         // validate dates
         $dtDate       = ValidateDate($iYear, $iMonth);

--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -70,7 +70,7 @@ class clsAWStats
         $this->sFileName = $sFileName;
 
         if (is_readable($sFilePath)) {
-            $this->sAWStats = htmlspecialchars(file_get_contents($sFilePath));
+            $this->sAWStats = htmlspecialchars(file_get_contents($sFilePath), ENT_SUBSTITUTE);
             $this->bLoaded  = true;
         }
         else

--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -424,6 +424,7 @@ function GetLogList($sStatsName, $sFilePath, $sFileName = "", $sParts = "")
                 $aTemp[] = mktime(0, 0, 0, intval($sMonth), 1, intval($sYear));
             }
         }
+        closedir($oDir);
         if (count($aTemp) < 1) {
             Error("NoLogsFound", $GLOBALS["g_sConfig"]);
         }

--- a/clsAWStats.php
+++ b/clsAWStats.php
@@ -270,7 +270,7 @@ class clsAWStats
             return array();
         $iEndPos   = strpos($this->sAWStats, ("\nEND_" . $sSection), $iStartPos);
         $max       = 0;
-        $aDesc     = $GLOBALS["aDesc"];
+        $aDesc     = array();#$GLOBALS["aDesc"];
         if (isset($_GET["max"]))
             $max       = $_GET["max"];
         $arrStat   = explode("\n", substr($this->sAWStats, ($iStartPos + 1), ($iEndPos - $iStartPos - 1)));

--- a/clsPage.php
+++ b/clsPage.php
@@ -117,7 +117,7 @@ class clsPage
     function DrawFooter()
     {
         $aString = explode("_", str_replace("]", "]_", str_replace("[", "_[", Lang("Powered by [AWSTART]AWStats[END]. Made beautiful by [JAWSTART]JAWStats Web Statistics and Analytics[END]."))));
-        for ($i = 0; $i < count($aString); $i++) {
+        for ($i = 0; $i < count($aString) - 1; $i++) {
             if ((strlen(trim($aString[$i])) > 0) && (substr($aString[$i], 0, 1) != "[") && (substr($aString[$i + 1], 0, 5) != "[END]")) {
                 $aString[$i] = ("<span>" . $aString[$i] . "</span>");
             } else {

--- a/clsPage.php
+++ b/clsPage.php
@@ -32,7 +32,7 @@ class clsPage
     var $sSubMenuJS = "";
     var $aViews     = array();
 
-    function clsPage($type = "")
+    function __construct($type = "")
     {
         if (strlen($type) == 0) {
             $type = "web";

--- a/clsPage.php
+++ b/clsPage.php
@@ -187,7 +187,7 @@ function ToolChangeLanguage()
     $aHTML[] = "</ul>\n</td>\n</tr>\n</table>";
     $aHTML[] = "</div></div>";
 
-    return implode($aHTML, "\n");
+    return implode("\n", $aHTML);
 }
 
 function ToolChangeMonth()
@@ -230,7 +230,7 @@ function ToolChangeMonth()
     $aHTML[] = "</table>";
     $aHTML[] = "</div></div>";
 
-    return implode($aHTML, "\n");
+    return implode("\n", $aHTML);
 }
 
 function ToolChangeSite()
@@ -270,7 +270,7 @@ function ToolChangeSite()
     $aHTML[] = "</ul>\n</td>\n</tr>\n</table>";
     $aHTML[] = "</div></div>";
 
-    return implode($aHTML, "\n");
+    return implode("\n", $aHTML);
 }
 
 function ToolUpdateSite()
@@ -286,7 +286,7 @@ function ToolUpdateSite()
     $aHTML[] = "<input type=\"password\" id=\"password\" onkeyup=\"UpdateSiteKeyUp(event)\" />";
     $aHTML[] = "<input type=\"button\" onclick=\"UpdateSite()\" value=\"" . Lang("Update") . "\" />";
     $aHTML[] = "</div>\n</div>\n</div>";
-    return implode($aHTML, "\n");
+    return implode("\n", $aHTML);
 }
 
 function ToolChangeParts($sParts, $arrMissingParts)
@@ -306,5 +306,5 @@ function ToolChangeParts($sParts, $arrMissingParts)
     }
     $aHTML[] = "</td>\n</tr>\n</table>";
     $aHTML[] = "</div>\n</div>";
-    return implode($aHTML, "\n");
+    return implode("\n", $aHTML);
 }


### PR DESCRIPTION
If the awstats data file is iso-8859, htmlspecialchars barfs and returns an empty string, and thus clsAwstats cant parse the file, and returns 0 visits/pages/etc. Adding ENT_SUBSTITUTE worksaround this..
